### PR TITLE
experiment - use first taskrun as anchor pod

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -29,7 +29,7 @@ data:
   # See more in the workspace documentation about Affinity Assistant
   # https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#affinity-assistant-and-specifying-workspace-order-in-a-pipeline
   # or https://github.com/tektoncd/pipeline/pull/2630 for more info.
-  disable-affinity-assistant: "false"
+  disable-affinity-assistant: "true"
   # Setting this flag to "true" will prevent Tekton scanning attached
   # service accounts and injecting any credentials it finds into your
   # Steps.

--- a/examples/experiment/basic.yaml
+++ b/examples/experiment/basic.yaml
@@ -1,0 +1,34 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: demo-pipeline-four-tasks
+spec:
+  tasks:
+    - name: say-hello
+      taskSpec:
+        steps:
+        - image: busybox
+          command: ["/bin/sh", "-c"]
+          args:
+            - echo hello
+    - name: say-word
+      taskSpec:
+        steps:
+        - image: busybox
+          command: ["/bin/sh", "-c"]
+          args:
+            - echo word
+    - name: say-hello-again
+      taskSpec:
+        steps:
+        - image: busybox
+          command: ["/bin/sh", "-c"]
+          args:
+            - echo hello again
+    - name: say-word-again
+      taskSpec:
+        steps:
+        - image: busybox
+          command: ["/bin/sh", "-c"]
+          args:
+            - echo world again

--- a/examples/experiment/basicrun.yaml
+++ b/examples/experiment/basicrun.yaml
@@ -1,0 +1,8 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: demo-pipeline-four-tasks-
+spec:
+  pipelineRef:
+    name: demo-pipeline-four-tasks
+    

--- a/pkg/internal/experimentpod/transformer.go
+++ b/pkg/internal/experimentpod/transformer.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package experimentpod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/pod"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewTransformer returns a pod.Transformer that will pod affinity if needed
+func NewTransformer(_ context.Context, annotations map[string]string) pod.Transformer {
+	return func(p *corev1.Pod) (*corev1.Pod, error) {
+		// if it is an anchor pod, don't append pod affinity
+		if isFirstPod := annotations["first-pod"]; isFirstPod == "true" {
+			return p, nil
+		}
+
+		if p.Spec.Affinity == nil {
+			p.Spec.Affinity = &corev1.Affinity{}
+		}
+
+		anchorPod, ok := annotations["anchor-pod"]
+		if !ok {
+			return p, fmt.Errorf("missing anchor pod")
+		}
+
+		mergeAffinityWithAnchorPod(p.Spec.Affinity, anchorPod)
+		return p, nil
+	}
+}
+
+func mergeAffinityWithAnchorPod(affinity *corev1.Affinity, anchorPodName string) {
+	podAffinityTerm := podAffinityTermUsingAnchorPod(anchorPodName)
+
+	if affinity.PodAffinity == nil {
+		affinity.PodAffinity = &corev1.PodAffinity{}
+	}
+
+	affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution =
+		append(affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution, *podAffinityTerm)
+}
+
+func podAffinityTermUsingAnchorPod(anchorPodName string) *corev1.PodAffinityTerm {
+	return &corev1.PodAffinityTerm{LabelSelector: &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"anchor-pod": anchorPodName,
+		},
+	},
+		TopologyKey: "kubernetes.io/hostname",
+	}
+}

--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -104,6 +104,12 @@ func (c *Reconciler) cleanupAffinityAssistants(ctx context.Context, pr *v1beta1.
 	return errorutils.NewAggregate(errs)
 }
 
+func getExperimentAnchorPodName(pipelineRunName string) string {
+	hashBytes := sha256.Sum256([]byte(pipelineRunName))
+	hashString := fmt.Sprintf("%x", hashBytes)
+	return fmt.Sprintf("%s-%s", "anchor-pod", hashString[:10])
+}
+
 func getAffinityAssistantName(pipelineWorkspaceName string, pipelineRunName string) string {
 	hashBytes := sha256.Sum256([]byte(pipelineWorkspaceName + pipelineRunName))
 	hashString := fmt.Sprintf("%x", hashBytes)

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -36,6 +36,7 @@ import (
 	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/internal/affinityassistant"
 	"github.com/tektoncd/pipeline/pkg/internal/computeresources"
+	"github.com/tektoncd/pipeline/pkg/internal/experimentpod"
 	resolutionutil "github.com/tektoncd/pipeline/pkg/internal/resolution"
 	podconvert "github.com/tektoncd/pipeline/pkg/pod"
 	tknreconciler "github.com/tektoncd/pipeline/pkg/reconciler"
@@ -719,6 +720,7 @@ func (c *Reconciler) createPod(ctx context.Context, ts *v1beta1.TaskSpec, tr *v1
 	pod, err := podbuilder.Build(ctx, tr, *ts,
 		computeresources.NewTransformer(ctx, tr.Namespace, c.limitrangeLister),
 		affinityassistant.NewTransformer(ctx, tr.Annotations),
+		experimentpod.NewTransformer(ctx, tr.Annotations),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("translating TaskSpec to Pod: %w", err)


### PR DESCRIPTION
This is an experiment to achieve node affinity without using placeholder pod as we do today in affinity assistant. In this experiment, the first PipelienTask pod is used as the "anchor" pod (which can be scheduled to any node). Pod affinity terms are only applied follow-up pods, so that the pods can be anchored to the first PipelineTask pod.

The main issue with this idea is that if the anchor pod finishes before the followup pods are started, it runs into scheduling conflict as there is no node meets the affinity requirement (inter pod affinity only considers running pods).

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
